### PR TITLE
fix: resolve 7 SonarQube code smells

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -10,3 +10,10 @@ License: MIT
 # UI Label Constants
 NOT_MAPPED = '-- Not Mapped --'
 NOT_SELECTED = '-- Not Selected --'
+
+# Default values for field mapping validation
+DEFAULT_NOT_MAPPED = "<Not Mapped>"
+
+# Date format constants
+DATE_FORMAT_DISPLAY = 'DD/MM/YYYY'
+DATE_FORMAT_STRPTIME = '%d/%m/%Y'

--- a/src/gui_conversion_handler.py
+++ b/src/gui_conversion_handler.py
@@ -111,8 +111,9 @@ class ConversionHandler:
         try:
             parser, generator = self._create_parser_and_generator(config)
 
-            date_validator = self._create_date_validator(config)
-            if date_validator is False:
+            try:
+                date_validator = self._create_date_validator(config)
+            except ValueError:
                 return (
                     False,
                     "Invalid date range for validation",
@@ -167,7 +168,10 @@ class ConversionHandler:
             config: ConversionConfig with date validation settings
 
         Returns:
-            DateValidator instance, None if disabled, or False on error
+            DateValidator instance or None if disabled
+
+        Raises:
+            ValueError: If date range is missing or invalid
         """
         if not config.enable_date_validation:
             return None
@@ -176,14 +180,9 @@ class ConversionHandler:
         end_date_str = config.statement_end_date.strip()
 
         if not start_date_str or not end_date_str:
-            return False
+            raise ValueError("Missing date range for validation")
 
-        try:
-            validator = DateValidator(start_date_str, end_date_str)
-            return validator
-        except ValueError as e:
-            logger.error("Invalid date range: %s", e)
-            return False
+        return DateValidator(start_date_str, end_date_str)
 
     def _process_csv_rows(
         self,


### PR DESCRIPTION
## Summary
- Extract duplicated string literals (`"<Not Mapped>"`, `'DD/MM/YYYY'`, `'%d/%m/%Y'`) into constants in `constants.py` (S1192)
- Refactor `validate_date_format()` into smaller helper functions (`_validate_ddmmyyyy`, `_validate_date_ranges`) to reduce cognitive complexity from 20 to under 15 (S3776)
- Fix inconsistent return type in `_create_date_validator()` by raising `ValueError` instead of returning `False`, aligning with the `Optional[DateValidator]` type hint (S5886)

## Test plan
- [x] All 499 tests passing with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)